### PR TITLE
Fix worker shutdown to safely disconnect tooz advertiser

### DIFF
--- a/zag/engines/worker_based/types.py
+++ b/zag/engines/worker_based/types.py
@@ -437,8 +437,13 @@ class ToozWorkerAdvertiser(object):
     def retract(self):
         for group_id in self._join_groups:
             try:
+                self._coordinator.leave_group(group_id).get()
+            except coordination.MemberNotJoined:
+                pass
+
+            try:
                 self._coordinator.delete_group(group_id).get()
-            except coordination.GroupAlreadyExist:
+            except coordination.GroupNotEmpty:
                 pass
 
     @periodics.periodic(BEAT_PERIOD, run_immediately=True)
@@ -456,8 +461,8 @@ class ToozWorkerAdvertiser(object):
         self.advertise()
 
     def stop(self):
-        self._activator.stop()
         self.retract()
+        self._activator.stop()
 
 
 class ToozWorkerFinder(WorkerFinder):

--- a/zag/engines/worker_based/worker.py
+++ b/zag/engines/worker_based/worker.py
@@ -192,13 +192,13 @@ class Worker(object):
 
     def stop(self):
         """Stop the worker component(s)."""
-        self._server.stop()
-        if self._owns_executor:
-            self._executor.shutdown()
-
         advertiser = self._fetch_advertiser()
         if advertiser is not None:
             advertiser.stop()
+
+        self._server.stop()
+        if self._owns_executor:
+            self._executor.shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Remove the worker from the group before attempting to remove the group
* Check for the right exception when removing group fails due to not being empty
* Fix the shutdown order of the various threads

I plan to remove the ProxyWorkerFinder and simplify how you set up the worker and
conductor and make using a Tooz-based backend the only option. That will allow us
to clean this up even further by not having so many branching paths.

Fixes #15