### PR TITLE
Add a FlowFactory type that can be inherited for flow factories

### DIFF
--- a/zag/tests/unit/test_conductors.py
+++ b/zag/tests/unit/test_conductors.py
@@ -33,6 +33,7 @@ from zag import states as st
 from zag import test
 from zag.test import mock
 from zag.tests import utils as test_utils
+from zag.types import flow_factory as ff_types
 from zag.utils import persistence_utils as pu
 from zag.utils import threading_utils
 
@@ -66,6 +67,13 @@ def test_store_factory():
     f = lf.Flow("test")
     f.add(test_utils.TaskMultiArg('task1'))
     return f
+
+
+class ClassBasedFactory(ff_types.FlowFactory):
+    def generate(self):
+        f = lf.Flow("test")
+        f.add(test_utils.TaskMultiArg('task1'))
+        return f
 
 
 def single_factory():
@@ -363,6 +371,39 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
             components.board.post('poke', lb,
                                   details={'flow_uuid': fd.uuid,
                                            'store': job_store})
+            self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
+            components.conductor.stop()
+            self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
+            self.assertFalse(components.conductor.dispatching)
+
+        persistence = components.persistence
+        with contextlib.closing(persistence.get_connection()) as conn:
+            lb = conn.get_logbook(lb.uuid)
+            fd = lb.find(fd.uuid)
+        self.assertIsNotNone(fd)
+        self.assertEqual(st.SUCCESS, fd.state)
+
+    def test_class_based_flow_factories(self):
+        components = self.make_components()
+        components.conductor.connect()
+        consumed_event = threading.Event()
+
+        def on_consume(state, details):
+            consumed_event.set()
+
+        store = {'x': True, 'y': False, 'z': None}
+
+        components.board.notifier.register(base.REMOVAL, on_consume)
+        with close_many(components.conductor, components.client):
+            t = threading_utils.daemon_thread(components.conductor.run)
+            t.start()
+            lb, fd = pu.temporary_flow_detail(components.persistence,
+                                              meta={'store': store})
+            engines.save_factory_details(fd, ClassBasedFactory,
+                                         [], {},
+                                         backend=components.persistence)
+            components.board.post('poke', lb,
+                                  details={'flow_uuid': fd.uuid})
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             components.conductor.stop()
             self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))

--- a/zag/tests/unit/test_engines.py
+++ b/zag/tests/unit/test_engines.py
@@ -1415,7 +1415,7 @@ class SerialEngineTest(EngineTaskTest,
             engine='serial',
             backend=self.backend,
             store=store,
-            **kwargs,
+            **kwargs
         )
 
     def test_correct_load(self):
@@ -1456,7 +1456,7 @@ class ParallelEngineWithThreadsTest(EngineTaskTest,
             engine='parallel',
             store=store,
             max_workers=self._EXECUTOR_WORKERS,
-            **kwargs,
+            **kwargs
         )
 
     def test_correct_load(self):
@@ -1502,7 +1502,7 @@ class ParallelEngineWithEventletTest(EngineTaskTest,
             engine='parallel',
             executor=executor,
             store=store,
-            **kwargs,
+            **kwargs
         )
 
 
@@ -1538,7 +1538,7 @@ class ParallelEngineWithProcessTest(EngineTaskTest,
             executor=executor,
             store=store,
             max_workers=self._EXECUTOR_WORKERS,
-            **kwargs,
+            **kwargs
         )
 
     def test_update_progress_notifications_proxied(self):
@@ -1648,7 +1648,7 @@ class WorkerBasedEngineTest(EngineTaskTest,
             flow_detail=flow_detail,
             backend=self.backend,
             store=store,
-            **kwargs,
+            **kwargs
         )
 
     def test_correct_load(self):

--- a/zag/types/flow_factory.py
+++ b/zag/types/flow_factory.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+class FlowFactory(object):
+    """Class-based flow factory function base class
+
+    In some cases, you might want all your flow factories to share some
+    functionality. This class provides a base class that you can inherit
+    from and still generate flow factories that work with zag.
+
+    These classes can be called like a function and return a flow defined
+    by an overridend `generate` method that you define. Arguments will be
+    passed to that method.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        self = object.__new__(cls)
+        return self.generate(*args, **kwargs)
+
+    def generate(self, *args, **kwargs):
+        # can't use @abc.abstractmethod here because it breaks the class
+        # inspection used by the conductor (returns abc.ABCMeta instead)
+        raise NotImplementedError()


### PR DESCRIPTION
There are use-cases where having a class-based flow factory makes
more sense than a flow factory function. This provides a base
class that works with the conductor that can be inherited from
for such cases.

Fixes #10