### PR TITLE
Add support for scheduled and delayed jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ htmlcov
 *.swp
 
 # PBR
-build
 AUTHORS
 ChangeLog
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,6 @@ pydot>=1.2.4 # MIT License
 
 # For improved/better wbe worker finding
 tooz>=1.19.0 # Apache-2.0
+
+# For scheduled jobs
+crontab>=0.22.3

--- a/zag/conductors/backends/impl_executor.py
+++ b/zag/conductors/backends/impl_executor.py
@@ -300,6 +300,11 @@ class ExecutorConductor(base.Conductor):
                         self._log.debug("Job already claimed or"
                                         " consumed: %s", job)
                     else:
+                        self._notifier.notify("job_claimed", {
+                            'job': job,
+                            'conductor': self,
+                            'persistence': self._persistence,
+                        })
                         try:
                             fut = executor.submit(self._dispatch_job, job)
                         except RuntimeError:

--- a/zag/persistence/models.py
+++ b/zag/persistence/models.py
@@ -265,7 +265,7 @@ class LogBook(object):
     def __len__(self):
         return len(self._flowdetails_by_id)
 
-    def copy(self, retain_contents=True):
+    def copy(self, retain_contents=True, retain_uuid=True):
         """Copies this logbook.
 
         Creates a shallow copy of this logbook. If this logbook contains
@@ -280,12 +280,18 @@ class LogBook(object):
         :rtype: :py:class:`.LogBook`
         """
         clone = copy.copy(self)
+
+        if not retain_uuid:
+            clone._uuid = uuidutils.generate_uuid()
+
         if not retain_contents:
             clone._flowdetails_by_id = {}
         else:
             clone._flowdetails_by_id = self._flowdetails_by_id.copy()
+
         if self.meta:
             clone.meta = self.meta.copy()
+
         return clone
 
 

--- a/zag/states.py
+++ b/zag/states.py
@@ -20,6 +20,7 @@ from zag import exceptions as exc
 CLAIMED = 'CLAIMED'
 COMPLETE = 'COMPLETE'
 UNCLAIMED = 'UNCLAIMED'
+DELAYED = 'DELAYED'
 
 # Flow states.
 FAILURE = 'FAILURE'

--- a/zag/tests/unit/jobs/test_entrypoint.py
+++ b/zag/tests/unit/jobs/test_entrypoint.py
@@ -21,20 +21,25 @@ from zake import fake_client
 from zag.jobs import backends
 from zag.jobs.backends import impl_redis
 from zag.jobs.backends import impl_zookeeper
+from zag.persistence.backends import impl_memory
 from zag import test
 
 
 class BackendFetchingTest(test.TestCase):
     def test_zk_entry_point_text(self):
+        p = impl_memory.MemoryBackend()
         conf = 'zookeeper'
-        with contextlib.closing(backends.fetch('test', conf)) as be:
+        with contextlib.closing(backends.fetch('test', conf,
+                                               persistence=p)) as be:
             self.assertIsInstance(be, impl_zookeeper.ZookeeperJobBoard)
 
     def test_zk_entry_point(self):
+        p = impl_memory.MemoryBackend()
         conf = {
             'board': 'zookeeper',
         }
-        with contextlib.closing(backends.fetch('test', conf)) as be:
+        with contextlib.closing(backends.fetch('test', conf,
+                                               persistence=p)) as be:
             self.assertIsInstance(be, impl_zookeeper.ZookeeperJobBoard)
 
     def test_zk_entry_point_existing_client(self):
@@ -44,6 +49,7 @@ class BackendFetchingTest(test.TestCase):
         }
         kwargs = {
             'client': existing_client,
+            'persistence': impl_memory.MemoryBackend(),
         }
         with contextlib.closing(backends.fetch('test', conf, **kwargs)) as be:
             self.assertIsInstance(be, impl_zookeeper.ZookeeperJobBoard)
@@ -51,12 +57,16 @@ class BackendFetchingTest(test.TestCase):
 
     def test_redis_entry_point_text(self):
         conf = 'redis'
-        with contextlib.closing(backends.fetch('test', conf)) as be:
+        p = impl_memory.MemoryBackend()
+        with contextlib.closing(backends.fetch('test', conf,
+                                               persistence=p)) as be:
             self.assertIsInstance(be, impl_redis.RedisJobBoard)
 
     def test_redis_entry_point(self):
         conf = {
             'board': 'redis',
         }
-        with contextlib.closing(backends.fetch('test', conf)) as be:
+        p = impl_memory.MemoryBackend()
+        with contextlib.closing(backends.fetch('test', conf,
+                                               persistence=p)) as be:
             self.assertIsInstance(be, impl_redis.RedisJobBoard)

--- a/zag/tests/unit/jobs/test_redis_job.py
+++ b/zag/tests/unit/jobs/test_redis_job.py
@@ -22,11 +22,11 @@ import testtools
 
 from zag import exceptions as excp
 from zag.jobs.backends import impl_redis
+from zag.persistence.backends import impl_memory
 from zag import states
 from zag import test
 from zag.tests.unit.jobs import base
 from zag.tests import utils as test_utils
-from zag.utils import persistence_utils as p_utils
 from zag.utils import redis_utils as ru
 
 
@@ -40,6 +40,8 @@ class RedisJobboardTest(test.TestCase, base.BoardTestMixin):
         client.close()
 
     def create_board(self, persistence=None):
+        if persistence is None:
+            persistence = impl_memory.MemoryBackend()
         namespace = uuidutils.generate_uuid()
         client = ru.RedisClient()
         config = {
@@ -58,7 +60,7 @@ class RedisJobboardTest(test.TestCase, base.BoardTestMixin):
 
         with base.connect_close(self.board):
             with self.flush(self.client):
-                self.board.post('test', p_utils.temporary_log_book())
+                self.board.post('test', test_utils.test_factory)
 
             self.assertEqual(1, self.board.job_count)
             possible_jobs = list(self.board.iterjobs(only_unclaimed=True))
@@ -80,7 +82,7 @@ class RedisJobboardTest(test.TestCase, base.BoardTestMixin):
     def test_posting_claim_same_owner(self):
         with base.connect_close(self.board):
             with self.flush(self.client):
-                self.board.post('test', p_utils.temporary_log_book())
+                self.board.post('test', test_utils.test_factory)
 
             self.assertEqual(1, self.board.job_count)
             possible_jobs = list(self.board.iterjobs(only_unclaimed=True))

--- a/zag/tests/unit/test_conductors.py
+++ b/zag/tests/unit/test_conductors.py
@@ -23,7 +23,6 @@ import testscenarios
 from zake import fake_client
 
 from zag.conductors import backends
-from zag import engines
 from zag.jobs.backends import impl_zookeeper
 from zag.jobs import base
 from zag.listeners import timing as timing_listener
@@ -34,7 +33,6 @@ from zag import test
 from zag.test import mock
 from zag.tests import utils as test_utils
 from zag.types import flow_factory as ff_types
-from zag.utils import persistence_utils as pu
 from zag.utils import threading_utils
 
 
@@ -47,12 +45,9 @@ def close_many(*closeables):
             c.close()
 
 
-def test_factory(blowup):
+def test_blowup_factory():
     f = lf.Flow("test")
-    if not blowup:
-        f.add(test_utils.ProgressingTask('test1'))
-    else:
-        f.add(test_utils.FailingTask("test1"))
+    f.add(test_utils.FailingTask("test1"))
     return f
 
 
@@ -158,12 +153,9 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, test_factory,
-                                         [False], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
+            job = components.board.post('poke', test_utils.test_factory)
+            lb = job.book
+            fd = job.load_flow_detail()
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             self.assertTrue(job_consumed_event.wait(test_utils.WAIT_TIMEOUT))
             self.assertFalse(job_abandoned_event.wait(1))
@@ -191,17 +183,11 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
             t = threading_utils.daemon_thread(
                 lambda: components.conductor.run(max_dispatches=5))
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, test_factory,
-                                         [False], {},
-                                         backend=components.persistence)
             for _ in range(5):
-                components.board.post('poke', lb,
-                                      details={'flow_uuid': fd.uuid})
+                components.board.post('poke', test_utils.test_factory)
                 self.assertTrue(consumed_event.wait(
                     test_utils.WAIT_TIMEOUT))
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
+            components.board.post('poke', test_utils.test_factory)
             components.conductor.stop()
             self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
             self.assertFalse(components.conductor.dispatching)
@@ -232,12 +218,10 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, test_factory,
-                                         [True], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
+            job = components.board.post('poke', test_blowup_factory)
+            lb = job.book
+            fd = job.load_flow_detail()
+
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             self.assertTrue(job_consumed_event.wait(test_utils.WAIT_TIMEOUT))
             self.assertFalse(job_abandoned_event.wait(1))
@@ -252,6 +236,39 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         self.assertIsNotNone(fd)
         self.assertEqual(st.REVERTED, fd.state)
 
+    def test_delayed_job(self):
+        components = self.make_components()
+        components.conductor.connect()
+        claimed_event = threading.Event()
+
+        def on_claimed(event, details):
+            if event == 'job_claimed':
+                claimed_event.set()
+
+        flow_store = {'x': True, 'y': False, 'z': None}
+
+        components.conductor.notifier.register("job_claimed", on_claimed)
+        with close_many(components.conductor, components.client):
+            t = threading_utils.daemon_thread(components.conductor.run)
+            t.start()
+            job = components.board.post_delayed(180, 'poke',
+                                                test_store_factory,
+                                                store=flow_store)
+            lb = job.book
+            fd = job.load_flow_detail()
+
+            self.assertFalse(claimed_event.wait(2))
+            components.conductor.stop()
+            self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
+            self.assertFalse(components.conductor.dispatching)
+
+        persistence = components.persistence
+        with contextlib.closing(persistence.get_connection()) as conn:
+            lb = conn.get_logbook(lb.uuid)
+            fd = lb.find(fd.uuid)
+        self.assertIsNotNone(fd)
+        self.assertIsNone(fd.state)
+
     def test_missing_store(self):
         components = self.make_components()
         components.conductor.connect()
@@ -264,12 +281,10 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, test_store_factory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
+            job = components.board.post('poke', test_store_factory)
+            lb = job.book
+            fd = job.load_flow_detail()
+
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             components.conductor.stop()
             self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
@@ -296,81 +311,11 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, test_store_factory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid,
-                                           'store': store})
-            self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
-            components.conductor.stop()
-            self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
-            self.assertFalse(components.conductor.dispatching)
+            job = components.board.post('poke', test_store_factory,
+                                        store=store)
+            lb = job.book
+            fd = job.load_flow_detail()
 
-        persistence = components.persistence
-        with contextlib.closing(persistence.get_connection()) as conn:
-            lb = conn.get_logbook(lb.uuid)
-            fd = lb.find(fd.uuid)
-        self.assertIsNotNone(fd)
-        self.assertEqual(st.SUCCESS, fd.state)
-
-    def test_flowdetails_store(self):
-        components = self.make_components()
-        components.conductor.connect()
-        consumed_event = threading.Event()
-
-        def on_consume(state, details):
-            consumed_event.set()
-
-        store = {'x': True, 'y': False, 'z': None}
-
-        components.board.notifier.register(base.REMOVAL, on_consume)
-        with close_many(components.conductor, components.client):
-            t = threading_utils.daemon_thread(components.conductor.run)
-            t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence,
-                                              meta={'store': store})
-            engines.save_factory_details(fd, test_store_factory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
-            self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
-            components.conductor.stop()
-            self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
-            self.assertFalse(components.conductor.dispatching)
-
-        persistence = components.persistence
-        with contextlib.closing(persistence.get_connection()) as conn:
-            lb = conn.get_logbook(lb.uuid)
-            fd = lb.find(fd.uuid)
-        self.assertIsNotNone(fd)
-        self.assertEqual(st.SUCCESS, fd.state)
-
-    def test_combined_store(self):
-        components = self.make_components()
-        components.conductor.connect()
-        consumed_event = threading.Event()
-
-        def on_consume(state, details):
-            consumed_event.set()
-
-        flow_store = {'x': True, 'y': False}
-        job_store = {'z': None}
-
-        components.board.notifier.register(base.REMOVAL, on_consume)
-        with close_many(components.conductor, components.client):
-            t = threading_utils.daemon_thread(components.conductor.run)
-            t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence,
-                                              meta={'store': flow_store})
-            engines.save_factory_details(fd, test_store_factory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid,
-                                           'store': job_store})
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             components.conductor.stop()
             self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
@@ -397,13 +342,10 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence,
-                                              meta={'store': store})
-            engines.save_factory_details(fd, ClassBasedFactory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid})
+            job = components.board.post('poke', ClassBasedFactory, store=store)
+
+            lb = job.book
+            fd = job.load_flow_detail()
             self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
             components.conductor.stop()
             self.assertTrue(components.conductor.wait(test_utils.WAIT_TIMEOUT))
@@ -448,13 +390,7 @@ class ManyConductorTest(testscenarios.TestWithScenarios,
         with close_many(components.conductor, components.client):
             t = threading_utils.daemon_thread(components.conductor.run)
             t.start()
-            lb, fd = pu.temporary_flow_detail(components.persistence)
-            engines.save_factory_details(fd, sleep_factory,
-                                         [], {},
-                                         backend=components.persistence)
-            components.board.post('poke', lb,
-                                  details={'flow_uuid': fd.uuid,
-                                           'store': {'duration': 2}})
+            components.board.post('poke', sleep_factory, store={'duration': 2})
             running_start_event.wait(test_utils.WAIT_TIMEOUT)
             components.conductor.stop()
             job_abandoned_event.wait(test_utils.WAIT_TIMEOUT)
@@ -506,13 +442,7 @@ class ListenerFactoryTest(test.TestCase):
             with close_many(components.conductor, components.client):
                 t = threading_utils.daemon_thread(components.conductor.run)
                 t.start()
-                lb, fd = pu.temporary_flow_detail(components.persistence,
-                                                  meta={'store': store})
-                engines.save_factory_details(fd, test_store_factory,
-                                             [], {},
-                                             backend=components.persistence)
-                components.board.post('poke', lb,
-                                      details={'flow_uuid': fd.uuid})
+                components.board.post('poke', test_store_factory, store=store)
                 self.assertTrue(consumed_event.wait(test_utils.WAIT_TIMEOUT))
                 components.conductor.stop()
                 self.assertTrue(components.conductor.wait(

--- a/zag/tests/unit/test_listeners.py
+++ b/zag/tests/unit/test_listeners.py
@@ -86,11 +86,12 @@ class TestClaimListener(test.TestCase, EngineMakerMixin):
         super(TestClaimListener, self).setUp()
         self.client = fake_client.FakeClient()
         self.addCleanup(self.client.stop)
-        self.board = jobs.fetch('test', 'zookeeper', client=self.client)
+        self.board = jobs.fetch('test', 'zookeeper', client=self.client,
+                                persistence=impl_memory.MemoryBackend())
         self.addCleanup(self.board.close)
         self.board.connect()
 
-    def _post_claim_job(self, job_name, book=None, details=None):
+    def _post_claim_job(self, job_name):
         arrived = threading.Event()
 
         def set_on_children(children):
@@ -98,7 +99,7 @@ class TestClaimListener(test.TestCase, EngineMakerMixin):
                 arrived.set()
 
         self.client.ChildrenWatch("/zag", set_on_children)
-        job = self.board.post('test-1')
+        job = self.board.post(job_name, test_utils.test_factory)
 
         # Make sure it arrived and claimed before doing further work...
         self.assertTrue(arrived.wait(test_utils.WAIT_TIMEOUT))

--- a/zag/tests/utils.py
+++ b/zag/tests/utils.py
@@ -25,6 +25,7 @@ import six
 
 from zag import exceptions
 from zag.listeners import capturing
+from zag.patterns import linear_flow as lf
 from zag.persistence.backends import impl_memory
 from zag import retry
 from zag import task
@@ -41,7 +42,7 @@ ZK_TEST_CONFIG = {
 }
 # If latches/events take longer than this to become empty/set, something is
 # usually wrong and should be debugged instead of deadlocking...
-WAIT_TIMEOUT = 300
+WAIT_TIMEOUT = 30
 
 
 @contextlib.contextmanager
@@ -446,3 +447,9 @@ def make_many(amount, task_cls=DummyTask, offset=0):
         offset += 1
         amount -= 1
     return tasks
+
+
+def test_factory():
+    f = lf.Flow("test")
+    f.add(ProgressingTask('test1'))
+    return f


### PR DESCRIPTION
Because jobs require persisent logbooks to function, we also stop
requiring the user to do all the bookkeeping externally
and handle it automatically inside the job board itself.

Some common functionality was factored out into base classes
to simplify job board implementation boilerplate. There's more
to do there, but it's a start.

Scheduled jobs work by posting a new job with the same details
after the job is consumed, if there is a next iteration remaining
on the schedule.

Delayed jobs are just jobs with a `run_at` timestamp that are
ignored until that time is no longer in the future.

We should probably move some of the fields from the job details dict
into top-level fields on the job to make them first-class citizens,
but that can wait.

Fixes #18