### PR TITLE
Give up on jobs after too many compilation errors

### DIFF
--- a/zag/conductors/backends/impl_blocking.py
+++ b/zag/conductors/backends/impl_blocking.py
@@ -30,14 +30,22 @@ class BlockingConductor(impl_executor.ExecutorConductor):
         return futurist.SynchronousExecutor()
 
     def __init__(self, name, jobboard,
-                 persistence=None, engine=None,
-                 engine_options=None, wait_timeout=None,
-                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
-                 listener_factories=None):
+                 persistence=None,
+                 engine=None,
+                 engine_options=None,
+                 wait_timeout=None,
+                 log=None,
+                 max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
+                 listener_factories=None,
+                 job_compiler_error_limit=None):
         super(BlockingConductor, self).__init__(
             name, jobboard,
-            persistence=persistence, engine=engine,
+            persistence=persistence,
+            engine=engine,
             engine_options=engine_options,
-            wait_timeout=wait_timeout, log=log,
+            wait_timeout=wait_timeout,
+            log=log,
             max_simultaneous_jobs=max_simultaneous_jobs,
-            listener_factories=listener_factories)
+            listener_factories=listener_factories,
+            job_compiler_error_limit=job_compiler_error_limit,
+        )

--- a/zag/conductors/backends/impl_nonblocking.py
+++ b/zag/conductors/backends/impl_nonblocking.py
@@ -51,17 +51,26 @@ class NonBlockingConductor(impl_executor.ExecutorConductor):
         return futurist.ThreadPoolExecutor(max_workers=max_workers)
 
     def __init__(self, name, jobboard,
-                 persistence=None, engine=None,
-                 engine_options=None, wait_timeout=None,
-                 log=None, max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
+                 persistence=None,
+                 engine=None,
+                 engine_options=None,
+                 wait_timeout=None,
+                 log=None,
+                 max_simultaneous_jobs=MAX_SIMULTANEOUS_JOBS,
                  executor_factory=None,
-                 listener_factories=None):
+                 listener_factories=None,
+                 job_compiler_error_limit=None):
         super(NonBlockingConductor, self).__init__(
             name, jobboard,
-            persistence=persistence, engine=engine,
-            engine_options=engine_options, wait_timeout=wait_timeout,
-            log=log, max_simultaneous_jobs=max_simultaneous_jobs,
-            listener_factories=listener_factories)
+            persistence=persistence,
+            engine=engine,
+            engine_options=engine_options,
+            wait_timeout=wait_timeout,
+            log=log,
+            max_simultaneous_jobs=max_simultaneous_jobs,
+            listener_factories=listener_factories,
+            job_compiler_error_limit=job_compiler_error_limit,
+        )
         if executor_factory is None:
             self._executor_factory = self._default_executor_factory
         else:


### PR DESCRIPTION
The conductor should trash jobs after it fails to run it a specified number
of times. The default value is 10 attempts, but it can be overridden via a
parameter or via subclassing.

Fixes #27