### PR TITLE
Add ABORT and IGNORE retry strategies

### DIFF
--- a/zag/engines/action_engine/engine.py
+++ b/zag/engines/action_engine/engine.py
@@ -321,7 +321,7 @@ class ActionEngine(base.Engine):
             except Exception:
                 with excutils.save_and_reraise_exception():
                     LOG.exception("Engine execution has failed, something"
-                                  " bad must of happened (last"
+                                  " bad must have happened (last"
                                   " %s machine transitions were %s)",
                                   last_transitions.maxlen,
                                   list(last_transitions))

--- a/zag/engines/action_engine/selector.py
+++ b/zag/engines/action_engine/selector.py
@@ -59,6 +59,8 @@ class Selector(object):
                 return self._browse_atoms_for_execute(atom=atom)
             else:
                 return iter([])
+        elif state == st.IGNORE and intention == st.IGNORE:
+            return self._browse_atoms_for_execute(atom=atom)
         elif state == st.REVERTED:
             return self._browse_atoms_for_revert(atom=atom)
         elif state == st.FAILURE:

--- a/zag/retry.py
+++ b/zag/retry.py
@@ -54,13 +54,35 @@ class Decision(misc.StrEnum):
     retry strategy associated with it.
     """
 
-    #: Retries the surrounding/associated subflow again.
     RETRY = "RETRY"
+    """Retries the surrounding/associated subflow.
+
+    This strategy will revert tasks within the associated subflow, then
+    re-run all the tasks again.
+    """
+
+    ABORT = "ABORT"
+    """Ends the entire flow immediately without reverting anything.
+
+    This strategy will just end the flow without marking anything as failed.
+    If you want a task to be able to short-circuit a flow without triggering
+    any error handling, this is what you want.
+    """
+
+    IGNORE = "IGNORE"
+    """Ends the subflow immediately and continues on to the remaining flow.
+
+    This strategy will abandon the associated subflow but continue processing
+    the outer flow as if the subflow had succeeded.
+    """
+
 
 # Retain these aliases for a number of releases...
 REVERT = Decision.REVERT
 REVERT_ALL = Decision.REVERT_ALL
 RETRY = Decision.RETRY
+ABORT = Decision.ABORT
+IGNORE = Decision.IGNORE
 
 # Constants passed into revert/execute kwargs.
 #
@@ -379,3 +401,23 @@ class ParameterizedForEach(ForEachBase):
 
     def execute(self, values, history, *args, **kwargs):
         return self._get_next_value(values, history)
+
+
+class AlwaysAbort(Retry):
+    """Retry that always aborts entire flow."""
+
+    def on_failure(self, *args, **kwargs):
+        return ABORT
+
+    def execute(self, *args, **kwargs):
+        pass
+
+
+class AlwaysIgnore(Retry):
+    """Retry that always ignores subflow."""
+
+    def on_failure(self, *args, **kwargs):
+        return IGNORE
+
+    def execute(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
ABORT will abandon the entire flow without marking anything as failed
IGNORE will ignore the error and continue on with the remainder of the flow
beyond the current subflow.

Fixes #26