### PR TITLE
Improve JSON-encoding failures to be more resilient

### DIFF
--- a/zag/types/failure.py
+++ b/zag/types/failure.py
@@ -515,11 +515,11 @@ class Failure(mixins.StrMixin):
         """
         try:
             primitive = zag_json.default(data)
-        except ValueError:
+        except (TypeError, ValueError, OverflowError):
             # last-ditch effort, try to force it to a string
             try:
                 primitive = six.text_type(data)
-            except TypeError:
+            except Exception:
                 primitive = data
 
         if not isinstance(primitive, six.string_types + (list, dict)):


### PR DESCRIPTION
We missed the most common JSON encoding error TypeError,
but also OverflowError is possible according to the docs.

Moved to base Exception type with the fallback to guarantee
that it's covered, as I can't find docs or an example of
failing to encode something as six.text_type(), but I would
imagine the only case would be throwing an exception from a
__repr__ method, which could be anything. So to be safe, just
trap everything.

Fixes #39