### PR TITLE
Avoid sqla and alembic warnings

### DIFF
--- a/zag/persistence/backends/impl_sqlalchemy.py
+++ b/zag/persistence/backends/impl_sqlalchemy.py
@@ -261,9 +261,13 @@ class SQLAlchemyBackend(base.Backend):
         conf = copy.deepcopy(conf)
         engine_args = {
             'echo': _as_bool(conf.pop('echo', False)),
-            'convert_unicode': _as_bool(conf.pop('convert_unicode', True)),
             'pool_recycle': 3600,
         }
+
+        if 'convert_unicode' in conf:
+            convert_unicode = _as_bool(conf.pop('convert_unicode', True))
+            engine_args['convert_unicode'] = convert_unicode
+
         if 'idle_timeout' in conf:
             idle_timeout = misc.as_int(conf.pop('idle_timeout'))
             engine_args['pool_recycle'] = idle_timeout

--- a/zag/persistence/backends/sqlalchemy/alembic/versions/1cea328f0f65_initial_logbook_deta.py
+++ b/zag/persistence/backends/sqlalchemy/alembic/versions/1cea328f0f65_initial_logbook_deta.py
@@ -41,17 +41,17 @@ def _get_indexes():
     # up and fetched, so attempt to ensure that that is done quickly.
     indexes = [
         {
-            'name': 'logbook_uuid_idx',
+            'index_name': 'logbook_uuid_idx',
             'table_name': 'logbooks',
             'columns': ['uuid'],
         },
         {
-            'name': 'flowdetails_uuid_idx',
+            'index_name': 'flowdetails_uuid_idx',
             'table_name': 'flowdetails',
             'columns': ['uuid'],
         },
         {
-            'name': 'taskdetails_uuid_idx',
+            'index_name': 'taskdetails_uuid_idx',
             'table_name': 'taskdetails',
             'columns': ['uuid'],
         },
@@ -63,7 +63,7 @@ def _get_foreign_keys():
     f_keys = [
         # Flow details uuid -> logbook parent uuid
         {
-            'name': 'flowdetails_ibfk_1',
+            'constraint_name': 'flowdetails_ibfk_1',
             'source': 'flowdetails',
             'referent': 'logbooks',
             'local_cols': ['parent_uuid'],
@@ -72,7 +72,7 @@ def _get_foreign_keys():
         },
         # Task details uuid -> flow details parent uuid
         {
-            'name': 'taskdetails_ibfk_1',
+            'constraint_name': 'taskdetails_ibfk_1',
             'source': 'taskdetails',
             'referent': 'flowdetails',
             'local_cols': ['parent_uuid'],


### PR DESCRIPTION
The `name` parameter was renamed in alembic 0.8.0 and we already require 0.8.10.
The `convert_unicode` parameter was deprecated in sqlalchemy 1.3, so only pass it along if we receive it.